### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/paraskuk/Rust-Fibonacci-REST-Kubernetes-Prometheus-Grafana/security/code-scanning/1](https://github.com/paraskuk/Rust-Fibonacci-REST-Kubernetes-Prometheus-Grafana/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only checks out the code, builds it, and runs tests, it does not require write permissions. The minimal permissions required are `contents: read`, which allows the workflow to read repository contents. This block can be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
